### PR TITLE
Fix position

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,12 +82,6 @@ fn tokenize(input: &mut Chars) -> Vec<Token> {
             res.push(token);
         }
     }
-    if !current_term.is_empty() {
-        res.push(Token::Term(
-          char_position - current_term.len(),
-          current_term,
-        ));
-    }
     res
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,14 +71,22 @@ fn tokenize(input: &mut Chars) -> Vec<Token> {
                 continue;
             }
         }
-        if current_term.len() > 0 {
-            res.push(Token::Term(char_position, current_term));
-            current_term = String::new();
+        if !current_term.is_empty() {
+            res.push(Token::Term(
+                char_position - current_term.len(),
+                current_term.clone(),
+            ));
+            current_term.clear();
         }
-        match next_token {
-            Some(token) => res.push(token),
-            None => ()
+        if let Some(token) = next_token {
+            res.push(token);
         }
+    }
+    if !current_term.is_empty() {
+        res.push(Token::Term(
+          char_position - current_term.len(),
+          current_term,
+        ));
     }
     res
 }


### PR DESCRIPTION
Hi, Thank you for your great blog post!

When debugging the Token, I found that Term position is not "the start" of the character but "the end" of the character.
```
(\a.\b.a) b
[LParen(1), Lambda(2), Term(4, "a"), Lambda(5), Term(7, "b"), Term(9, "a"), RParen(9), Term(12, "b")]
-> λb_1.b
```
I think this is not what you meant. So I fixed it.

```
(\a.\b.a) b
[LParen(1), Lambda(2), Term(3, "a"), Lambda(5), Term(6, "b"), Term(8, "a"), RParen(9), Term(11, "b")]
-> λb_1.b
```