### PR TITLE
Make lazy evaluation behave like normal evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ if false one two
 ## Contributors
 
 - [Ukuma012](https://github.com/Ukuma012)
+- [shrub!](https://github.com/shrub719)
 
 ## License
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,8 +288,8 @@ fn reduce_lazy(e: Expr, ctx: &HashMap<String, Expr>) -> Expr {
             else {
                 Expr::Var(v)
             }
-        }
-        _ => e
+        },
+        Expr::Abs(v, b) => Expr::Abs(v, Box::new(reduce_lazy(*b, ctx)))
     }
 }
 


### PR DESCRIPTION
Your [blog post](https://prose.nsood.in/rust-lambda) likens `reduce_lazy` to normal order evaluation:

> We can solve this problem by using another reduction strategy, known as “normal order evaluation”, or “lazy evaluation”. 

Right now, `reduce_lazy` does not behave exactly like a normal order evaluation. For instance, it will not always produce the normal form of an expression:

```
two = \f.\x.f(f(x))
-> two = λf.λx.f (f x)
two two
-> λx.two (two x)

# happens without identifiers too
(\f.\x.f(f(x))) (\f.\x.f(f(x)))
-> λx.(λf.λx.f (f x)) ((λf.λx.f (f x)) x)

# normal form is λf.λx.f (f (f (f x)))
```

Although they are equivalent, as can be seen when you apply it to `f` then `x` as you do in your blog.

As far as I can tell this is caused by not evaluating the body of an abstraction if you come across it in `reduce_lazy`. From my own testing, I don't believe doing so causes any errors aside from already-existing stack overflows with the Omega combinator and related.